### PR TITLE
Updates Interra components to 0.0.31 to fix babel-loader issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "axios": "^0.18.0",
     "bootstrap": "^4.2.1",
     "elasticlunr": "^0.9.5",
-    "interra-data-catalog-components": "0.0.30",
+    "interra-data-catalog-components": "0.0.31",
     "lodash": "^4.17.11",
     "node-sass": "^4.11.0",
     "papaparse": "^4.6.3",


### PR DESCRIPTION
Updates package.json to fix the babel-loader issue fixed in this commit:
https://github.com/interra/data-catalog-components/commit/c360fa08c9b4252635061eee9dda2d08301cb0f4